### PR TITLE
Remove copy to clipboard button

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@
     <div id="imagePreview">
       <p>No file currently selected for upload</p>
     </div>
-    <button id="copyImageHexBtn">copy image hex</button>
     <div class="imageHexHolder">
       <pre id="imageHex"></pre>
     </div>

--- a/main.js
+++ b/main.js
@@ -228,15 +228,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const textInput = document.getElementById("textInput");
   const imageInput = document.getElementById("imageInput");
   const imagePreview = document.getElementById("imagePreview");
-  const copyBtn = document.getElementById("copyImageHexBtn");
 
   imageInput.addEventListener("change", () => {
     updateImagePreview(imageInput, imagePreview);
-  });
-
-  copyBtn.addEventListener("click", (e) => {
-    const imageHexText = document.getElementById("imageHex");
-    navigator.clipboard.writeText(imageHexText.innerHTML);
   });
 
   document.getElementById("form").addEventListener("submit", (e) => {


### PR DESCRIPTION
Clipboard is disabled in insecure contexts (HTTP) :(

This is yet another thorn in our side stemming from running on the LAN (the other thorn is mDNS being unreliable). I think eventually we will want to host the frontend on the public internet and put it behind RC OAuth. This would solve both of these problems, and also make it possible to print to the hub remotely (unclear if desirable).